### PR TITLE
makefile: Use $(CC) for linking

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -102,7 +102,7 @@ $(TARGETNAME) : $(OBJNAMES)
 ifdef BUILD_WINDOWS
 	$(CPP) $(CPPFLAGS) -shared $^ $(LIBS) -o $@ 
 else
-	$(CPP) $(CPPFLAGS) -shared $^ $(LIBS) -Wl,-soname,$(TARGETSO) -o $@
+	$(CC) $(CPPFLAGS) -shared $^ $(LIBS) -Wl,-soname,$(TARGETSO) -o $@
 	cd $(BUILD_DIR); $(RM) $(TARGETSO); $(SOFTLINK) $(TARGET) $(TARGETSO)
 	cd $(BUILD_DIR); $(RM) $(TARGETBASE); $(SOFTLINK) $(TARGET) $(TARGETBASE)
 endif


### PR DESCRIPTION
For linking the C++ compiler is used, for compiling the C compiler. Use the C compiler
for linking as well to not pull extra build requirements on a C++ compiler.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>